### PR TITLE
Fix big white space on Firefox

### DIFF
--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -120,9 +120,12 @@ p {
 /* Screen-reader only */
 
 .sr-only {
-  position: absolute !important;
+  position: fixed !important;
   left: -10000px !important;
   bottom: -10000px !important;
+  width: 0 !important;
+  height: 0 !important;
+  overflow: hidden !important;
 }
 
 /* Lock the scroll position by adding this class to the `<html>` element. */


### PR DESCRIPTION
On firefox, bottom: -10000px is not interpreted the same way as Chrome. By using adding position:fixed and limiting dimension (height=width=0), the issue is fixed.

Related to: https://github.com/AlexandreCantin/katellea/issues